### PR TITLE
[Chore] 안드로이드 빌드 오류 해결 (#3

### DIFF
--- a/jumunseo/android/app/build.gradle
+++ b/jumunseo/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.jumunseo"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
image compressor와 image picker이 요구하는 최소 sdk버전이 21이라 고침

## #️⃣ 연관된 이슈
> ex) #3 


## 📝 작업 내용
>image compressor와 image picker이 요구하는 최소 sdk버전이 21이라 고침


### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
