### PR TITLE
[REFACTOR] #46 - 인증서버 user update 시에 refresh 토큰 변경 및 access 토큰 변경 로직 추가, 테스트 추가

### DIFF
--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/jwt/controller/JwtController.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/jwt/controller/JwtController.java
@@ -24,7 +24,7 @@ public class JwtController {
                                                     @CookieValue("refreshToken") String refreshToken) {
         // Access 재발급
         JwtTokenDto jwtTokenDto = refreshTokenService.refreshAccessJwtToken(accessToken,refreshToken);
-        // Refresh 재발급
+        // 쿠키 재발급
         ResponseCookie responseCookie = cookieProvider.createRefreshTokenCookie(refreshToken);
 
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString())

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/jwt/redis/RefreshToken.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/jwt/redis/RefreshToken.java
@@ -4,11 +4,12 @@ package com.jumunseo.authservice.domain.jwt.redis;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @NoArgsConstructor
-@RedisHash(value = "refreshToken") // 레디스에 저장될 해시 키
+@RedisHash(value = "refreshToken", timeToLive = 86400000) // 레디스에 저장될 해시 키
 @Getter
 public class RefreshToken {
 

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/dto/UpdateDto.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/dto/UpdateDto.java
@@ -1,0 +1,15 @@
+package com.jumunseo.authservice.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+public class UpdateDto {
+    private String email;
+    private String name;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserService.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.jumunseo.authservice.domain.user.service;
 
 import com.jumunseo.authservice.domain.user.dto.SignupDto;
+import com.jumunseo.authservice.domain.user.dto.UpdateDto;
 import com.jumunseo.authservice.domain.user.dto.UserDto;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public interface UserService {
 
     UserDto findUserByToken(String token);
     List<UserDto> findUsersByIds(List<Long> userIds);
-    UserDto updateUser(String token, Map<String,String> updateInfo);
+    UpdateDto updateUser(String token, Map<String,String> updateInfo);
     void deleteUser(String token);
     void deleteUserByEmail(String email);
 }

--- a/auth-service/src/main/java/com/jumunseo/authservice/global/util/JwtTokenProvider.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/global/util/JwtTokenProvider.java
@@ -22,10 +22,6 @@ public class JwtTokenProvider {
     @Value("${jwt.access_expiration}")
     private long accessTokenExpiration;
 
-    // OS 환경변수
-    @Value("${jwt.refresh_expiration}")
-    private long refreshTokenExpiration;
-
     private final UserRepository userRepository;
     private final String JwtPrefix = "Bearer ";
 
@@ -49,7 +45,6 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #46 


## 📝 작업 내용
> 유저 정보 업데이트 할때 레디스에 있는 refresh token 새로저장, 기존 토큰은 TTL적용해서 사라지게 함.
바디로 변경된 refresh token 과 acces token 전달
쿠키에 있는 refresh 토큰도 변경
해당 내용을 모두 커버하도록 userUpdate 테스트 수정


### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
