### PR TITLE
[FEATURE] #47 - 이메일 중복 예외 추가 및 중복 이메일 확인 API Endpoint 추가

### DIFF
--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/controller/UserController.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/controller/UserController.java
@@ -79,5 +79,8 @@ public class UserController {
     }
 
     // 이메일 중복 체크
-
+    @GetMapping("/duplicate/{email}")
+    public ResponseEntity<Result<?>> checkDuplicateEmail(@PathVariable String email) {
+        return ResponseEntity.ok(Result.successResult(userService.duplicateEmailCheck(email)));
+    }
 }

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/exception/DuplicateEmailException.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/exception/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package com.jumunseo.authservice.domain.user.exception;
+
+import com.jumunseo.authservice.global.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEmailException extends CustomException {
+    public DuplicateEmailException(String message) {
+        super(HttpStatus.CONFLICT, message);
+    }
+}

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserService.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserService.java
@@ -18,4 +18,5 @@ public interface UserService {
     UpdateDto updateUser(String token, Map<String,String> updateInfo);
     void deleteUser(String token);
     void deleteUserByEmail(String email);
+    boolean duplicateEmailCheck(String email);
 }

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserServiceImpl.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserServiceImpl.java
@@ -144,4 +144,8 @@ public class UserServiceImpl implements UserService, UserDetailsService{
                 .authorities(authority)
                 .build();
     }
+    @Override
+    public boolean duplicateEmailCheck(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
 }

--- a/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserServiceImpl.java
+++ b/auth-service/src/main/java/com/jumunseo/authservice/domain/user/service/UserServiceImpl.java
@@ -7,6 +7,7 @@ import com.jumunseo.authservice.domain.user.dto.SignupDto;
 import com.jumunseo.authservice.domain.user.dto.UpdateDto;
 import com.jumunseo.authservice.domain.user.dto.UserDto;
 import com.jumunseo.authservice.domain.user.entity.User;
+import com.jumunseo.authservice.domain.user.exception.DuplicateEmailException;
 import com.jumunseo.authservice.domain.user.exception.NotExistUserException;
 import com.jumunseo.authservice.domain.user.repository.UserRepository;
 import com.jumunseo.authservice.global.util.JwtTokenProvider;
@@ -46,7 +47,10 @@ public class UserServiceImpl implements UserService, UserDetailsService{
 
 
     @Override
-    public void saveUser(SignupDto signupDto) {
+    public void saveUser(SignupDto signupDto) throws DuplicateEmailException {
+        if(userRepository.findByEmail(signupDto.getEmail()).isPresent()) {
+            throw new DuplicateEmailException("Email already exists");
+        }
         userRepository.save(mapper.toEntity(signupDto));
     }
 

--- a/auth-service/src/test/java/com/jumunseo/authservice/controller/user/UserControllerTest.java
+++ b/auth-service/src/test/java/com/jumunseo/authservice/controller/user/UserControllerTest.java
@@ -273,7 +273,25 @@ public class UserControllerTest {
 
     @Test
     @DisplayName("아이디 중복 테스트")
+    @Transactional
     //Get Test
-    void checkDuplicateId() {
+    void checkDuplicateId() throws Exception {
+        //Given
+        setUp();
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/user/duplicate/Test"));
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("SUCCESS"))
+                .andExpect(jsonPath("message").value(""))
+                .andExpect(jsonPath("data").value("true"));
+
+        // When
+        ResultActions resultActions2 = mockMvc.perform(MockMvcRequestBuilders.get("/user/duplicate/NotTest"));
+        // Then
+        resultActions2.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("SUCCESS"))
+                .andExpect(jsonPath("message").value(""))
+                .andExpect(jsonPath("data").value("false"));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #47 


## 📝 작업 내용
> 회원가입시 중복된 이메일이면 예외 발생시키도록
회원가입 전에 호출할 이메일 중복 여부 확인 api 추가
중복 확인 테스트 추가 


### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
