### PR TITLE
[FEATURE] #57 마법사 대화삭제 기능 추가 + CORS 전체오픈

### DIFF
--- a/magician/main.py
+++ b/magician/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, WebSocket
+from fastapi.middleware.cors import CORSMiddleware
 import asyncio
 import uvicorn
 import motor.motor_asyncio
@@ -81,6 +82,7 @@ async def save_chat(user_id, room_id, added_prompt, conversation, is_continued):
 
 
 # READ
+# TODO: CQRS 패턴으로 변경
 # 어떤 사용자가 진행했던 채팅들 리스트 반환
 @app.get("/chat/list/{user_id}")
 async def chat_list(user_id: str):
@@ -92,12 +94,20 @@ async def chat_list(user_id: str):
 
 
 # READ
+# TODO: CQRS 패턴으로 변경
 # 어떤 채팅의 디테일 내용을 반환
 @app.get("/chat/{room_id}")
 async def chat_detail(room_id: str):
     chat = await collection.find_one({"room_id": room_id})
     chat["_id"] = str(chat["_id"])
     return {"chat": chat}
+
+# DELETE
+# 채팅방의 채팅 내용 삭제
+@app.delete("/chat/{room_id}")
+async def delete_chat(room_id: str):
+    await collection.delete_one({"room_id": room_id})
+    return {"message": "Chat deleted successfully"}
 
 
 # FastAPI 서버 실행

--- a/magician/main.py
+++ b/magician/main.py
@@ -10,6 +10,18 @@ import os
 
 app = FastAPI()
 
+# CORS
+# TODO: CORS 수정하기
+origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 # Asyncio 이벤트 루프 생성
 loop = asyncio.get_event_loop()
 

--- a/magician/test_magician.py
+++ b/magician/test_magician.py
@@ -4,6 +4,8 @@ import motor.motor_asyncio
 import asyncio
 import os
 import websockets
+from httpx import AsyncClient
+from main import app
 
 MAGICIAN_MONGO_USERNAME = os.getenv("MAGICIAN_MONGO_USERNAME")
 MAGICIAN_MONGO_PASSWORD = os.getenv("MAGICIAN_MONGO_PASSWORD")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #57 


## 📝 작업 내용
> 마법사 대화내용을 삭제하는 API추가
대화내용 삭제 API를 HTTPX.AsyncClient를 이용한 테스트 구현
또한 마법사 서버의 CORS 를 모두 오픈함으로서 테스트 가능하게 바꿈.
 

### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
