### PR TITLE
[FEATURE] #88 MSA 의 CUD,R 의 분리를 위한 Kafka(CUD) 적용과 WebFlux(R) 적용 

### DIFF
--- a/composite-service/build.gradle
+++ b/composite-service/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	implementation 'org.apache.kafka:kafka-streams'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.netty:netty-resolver-dns-native-macos'
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 	// https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api
 	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/MagicianCommandController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/MagicianCommandController.java
@@ -1,0 +1,40 @@
+package com.jumunseo.compositeservice.command.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jumunseo.compositeservice.command.dto.CommandDto;
+import com.jumunseo.compositeservice.command.service.KafkaService;
+import com.jumunseo.compositeservice.global.exception.Result;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+
+@RequiredArgsConstructor
+@RequestMapping ("/command/magician")
+@Controller
+public class MagicianCommandController {
+
+    private final KafkaService kafkaService;
+
+    @DeleteMapping("/{room_id}")
+    @Secured("USER")
+    public ResponseEntity<Result<?>> deleteChat(HttpServletRequest request, @PathVariable String room_id) throws JsonProcessingException {
+        // 요청 자체의 정보 (데이터 + 토큰정보)
+        CommandDto data = new CommandDto();
+
+        // 데이터를 Map으로 받아서 String으로 변환 for Kafka
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestStr = objectMapper.writeValueAsString(Map.of("room_id", room_id));
+
+        // 각각의 메시지를 나눠서 다른 토픽으로 보내기
+        CommandDto sending_data = kafkaService.setMessage(request, data, requestStr, "DeleteChat");
+        kafkaService.send("magician", sending_data);
+        return ResponseEntity.ok(Result.successResult(null));
+    }
+}

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/TestCommandController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/TestCommandController.java
@@ -10,43 +10,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.Map;
 
-
+@RequestMapping ("/command/test")
 @RequiredArgsConstructor
-@RequestMapping ("/command")
 @Controller
-public class CommandController {
-
+public class TestCommandController {
     private final KafkaService kafkaService;
 
-    // User는 카프카 사용 x, 토큰만 필요하거나, 토큰조차 필요 없는 경우가 많아 비효율적일것으로 예상.
-    // 만약 헤더나 PathVariable로 받아야할 경우가 생긴다면, CommandDto에 그냥 String으로 추가.
-    // 만약 바디로 들어온다면 ExternalDto를 만들고, CommandDto에 ExternalDto를 추가.
-
-    // Magician
-    // Community
-    @DeleteMapping("/chat/{room_id}")
-    @Secured("USER")
-    public ResponseEntity<Result<?>> deleteChat(HttpServletRequest request, @PathVariable String room_id) throws JsonProcessingException {
-        // 요청 자체의 정보 (데이터 + 토큰정보)
-        CommandDto data = new CommandDto();
-
-        // 데이터를 Map으로 받아서 String으로 변환 for Kafka
-        ObjectMapper objectMapper = new ObjectMapper();
-        String requestStr = objectMapper.writeValueAsString(Map.of("room_id", room_id));
-
-        // 각각의 메시지를 나눠서 다른 토픽으로 보내기
-        CommandDto sending_data = kafkaService.setMessage(request, data, requestStr, "DeleteChat");
-        kafkaService.send("magician", sending_data);
-        return ResponseEntity.ok(Result.successResult(null));
-    }
-
-    // Debate
-
-    @PostMapping("/test")
+    @PostMapping("")
     @Secured("USER")
     public ResponseEntity<Result<?>> test(HttpServletRequest request, @RequestBody Map<String,Object> body) throws JsonProcessingException {
         // 요청 자체의 정보 (데이터 + 토큰정보)

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/config/WebClientConfig.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/config/WebClientConfig.java
@@ -1,0 +1,36 @@
+package com.jumunseo.compositeservice.query.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webclient() {
+        // 연결 타임아웃, 읽기 타임아웃, 쓰기 타임아웃 설정
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(java.time.Duration.ofMillis(5000))
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(5000, TimeUnit.MILLISECONDS))
+                                .addHandlerLast(new WriteTimeoutHandler(5000, TimeUnit.MILLISECONDS)));
+
+
+
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/MagicianQueryController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/MagicianQueryController.java
@@ -1,0 +1,79 @@
+package com.jumunseo.compositeservice.query.controller;
+
+import com.jumunseo.compositeservice.global.exception.CustomException;
+import com.jumunseo.compositeservice.global.exception.Result;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/query/magician")
+@Controller
+public class MagicianQueryController {
+    private final String MAGICIN_SERVICE_URL = "http://localhost:8000";
+    private final WebClient webClient;
+
+    // Flux
+    // 유저 이름에 맞는 채팅방 리스트 가져오기
+    @GetMapping("/list/{user_id}")
+    public ResponseEntity<Result<?>> get_by_userId(HttpServletRequest req, @PathVariable String user_id) {
+        Flux<JSONObject> flux = webClient.get()
+                .uri(MAGICIN_SERVICE_URL + "/chat/list/" + user_id)
+                .header("email", req.getAttribute("email").toString())
+                .header("role", req.getAttribute("role").toString())
+                .header("name", req.getAttribute("name").toString())
+                .retrieve()
+                // 4-- 에러 -> 요청 오류
+                .onStatus(HttpStatusCode::is4xxClientError, res -> Mono.error(
+                        new CustomException(HttpStatus.valueOf(res.statusCode().value()),
+                                res.bodyToMono(String.class).toString())
+                ))
+                // 5-- 에러 -> 시스템 오류
+                .onStatus(HttpStatusCode::is5xxServerError, res -> Mono.error(
+                        new CustomException(HttpStatus.valueOf(res.statusCode().value()),
+                                res.bodyToMono(String.class).toString())
+                ))
+                .bodyToFlux(JSONObject.class);
+
+        List<JSONObject> chatlist = flux.collectList().block();
+        return ResponseEntity.ok(Result.successResult(chatlist));
+    }
+
+    // Mono
+    // 채팅방 아이디에 맞는 채팅방 가져오기
+    @GetMapping("/{room_id}")
+    public ResponseEntity<Result<?>> get_by_roomId(HttpServletRequest req, @PathVariable String room_id) {
+        Mono<JSONObject> mono = webClient.get()
+                .uri(MAGICIN_SERVICE_URL + "/chat/" + room_id)
+                .header("email", req.getAttribute("email").toString())
+                .header("role", req.getAttribute("role").toString())
+                .header("name", req.getAttribute("name").toString())
+                .retrieve()
+                // 4-- 에러 -> 요청 오류
+                .onStatus(HttpStatusCode::is4xxClientError, res -> Mono.error(
+                        new CustomException(HttpStatus.valueOf(res.statusCode().value()),
+                                res.bodyToMono(String.class).toString())
+                ))
+                // 5-- 에러 -> 시스템 오류
+                .onStatus(HttpStatusCode::is5xxServerError, res -> Mono.error(
+                        new CustomException(HttpStatus.valueOf(res.statusCode().value()),
+                                res.bodyToMono(String.class).toString())
+                ))
+                .bodyToMono(JSONObject.class);
+
+        return ResponseEntity.ok(Result.successResult(mono.block()));
+    }
+}

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/QueryController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/QueryController.java
@@ -1,7 +1,0 @@
-package com.jumunseo.compositeservice.query.controller;
-
-import org.springframework.stereotype.Controller;
-
-@Controller
-public class QueryController {
-}

--- a/composite-service/src/test/java/com/jumunseo/compositeservice/kafka_test/TestListener.java
+++ b/composite-service/src/test/java/com/jumunseo/compositeservice/kafka_test/TestListener.java
@@ -33,7 +33,7 @@ public class TestListener {
     Map<String,Object> map;
 
 
-    @KafkaListener(topics = "test", groupId = "test_consumer")
+    @KafkaListener(topics = "test", groupId = "test")
     public void listen(String message) throws JsonProcessingException {
         // 받은 데이터를 Map으로 변환 -> with 토큰정보 & 데이터
         map = objectMapper.readValue(message, new TypeReference<>() {});

--- a/magician/magician-env-docker-compose.yml
+++ b/magician/magician-env-docker-compose.yml
@@ -42,7 +42,8 @@ services:
       - "9092:9092"
     environment:
       KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
-      KAFKA_CREATE_TOPICS: "test:1:1"
+      # 여기다가 토픽 확장하기.
+      KAFKA_CREATE_TOPICS: "test:1:1, magician:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock

--- a/magician/magician-env-docker-compose.yml
+++ b/magician/magician-env-docker-compose.yml
@@ -29,3 +29,22 @@ services:
       MAGICIAN_MONGO_PORT: 27017
       MAGICIAN_MONGO_HOST: mongodb
 
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_CREATE_TOPICS: "test:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock
+    depends_on:
+      - zookeeper

--- a/magician/main.py
+++ b/magician/main.py
@@ -128,7 +128,7 @@ async def chat_list(user_id: str):
     async for chat in collection.find({"user_id": user_id}):
         chat["_id"] = str(chat["_id"])
         chats.append(chat)
-    return {"chats": chats}
+    return chats
 
 
 # READ
@@ -138,7 +138,7 @@ async def chat_list(user_id: str):
 async def chat_detail(room_id: str):
     chat = await collection.find_one({"room_id": room_id})
     chat["_id"] = str(chat["_id"])
-    return {"chat": chat}
+    return chat
 
 
 # DELETE

--- a/magician/requirements.txt
+++ b/magician/requirements.txt
@@ -1,4 +1,6 @@
+aiokafka==0.10.0
 anyio==4.2.0
+asgi-lifespan==2.1.0
 async-timeout==4.0.3
 certifi==2024.2.2
 click==8.1.7
@@ -10,6 +12,7 @@ httpcore==1.0.4
 httpx==0.27.0
 idna==3.4
 iniconfig==2.0.0
+kafka-python==2.0.2
 motor==3.3.2
 openai==1.13.3
 packaging==23.2

--- a/magician/test_magician.py
+++ b/magician/test_magician.py
@@ -81,23 +81,3 @@ async def test_reload_message(chat_collection):
 
     await chat_collection.delete_many({"user_id": "Test3"})
     assert msg[-1]["user_message"] == "reload_테스트2" and msg2 == "이전 대화를 이어서 진행합니다."
-
-@pytest.mark.asyncio(scope="session")
-@pytest.mark.dependency(depends=["test_reload_message"])
-async def test_delete_chat(chat_collection):
-    async with websockets.connect("ws://0.0.0.0:8000/ws/Test4") as websocket:
-        await websocket.send("test/-1")
-        await websocket.send("delete_테스트")
-        await websocket.recv()
-        await websocket.close()
-
-    await asyncio.sleep(3)
-    raw_room_id = await chat_collection.find_one({"user_id": "Test4"})
-    room_id = raw_room_id["room_id"]
-
-    test_client = AsyncClient(app=app, base_url="http://0.0.0.0:8000")
-    test_response = await test_client.delete(f"/chat/{room_id}")
-    assert test_response.status_code == 200
-
-    result = await chat_collection.find_one({"room_id": room_id})
-    assert result is None

--- a/magician/test_magician.py
+++ b/magician/test_magician.py
@@ -4,8 +4,7 @@ import motor.motor_asyncio
 import asyncio
 import os
 import websockets
-from httpx import AsyncClient
-from main import app
+
 
 MAGICIAN_MONGO_USERNAME = os.getenv("MAGICIAN_MONGO_USERNAME")
 MAGICIAN_MONGO_PASSWORD = os.getenv("MAGICIAN_MONGO_PASSWORD")
@@ -13,7 +12,6 @@ MAGICIAN_MONGO_PORT = os.getenv("MAGICIAN_MONGO_PORT")
 MAGICIAN_MONGO_HOST = os.getenv("MAGICIAN_MONGO_HOST")
 db_name = "chat_db"
 MONGO_URI = f"mongodb://{MAGICIAN_MONGO_USERNAME}:{MAGICIAN_MONGO_PASSWORD}@{MAGICIAN_MONGO_HOST}:{MAGICIAN_MONGO_PORT}/{db_name}?authSource=admin"
-
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 resolved #88 


## 📝 작업 내용
> Auth 서버를 들리지 않는 모든 요청을 Composite 서버를 통해 처리한다. 이를 위해 Command의 Kafka 와 Read의 WebFlux 를 적용했다. 
우선 서비스 가능한 마법사에 있어서 적용 완료.
전체 대화 리스트 : [GET] /query/magician/list/{user_id}
채팅방 대화 내역: [GET] /query/magician/{room_id}
채팅 삭제 : [DELETE] /command/magician/{room_id}

이 방법을 이용해서 추후에 구현할 다른 내용들 구현 가능.
### ***📸 스크린샷 (선택)***
### 단건조회
<img width="908" alt="스크린샷 2024-04-11 오후 12 48 39" src="https://github.com/kookmin-sw/capstone-2024-19/assets/91869302/6cdccd7b-67cc-4a38-9504-b30e8be17e5d">

### 다중조회 
<img width="906" alt="스크린샷 2024-04-11 오후 12 49 36" src="https://github.com/kookmin-sw/capstone-2024-19/assets/91869302/22ce76e1-488d-4e68-89da-11a339e44935">

## ***💬 리뷰 요구사항(선택)***
@dbtkdfhr 우선 마법사의 엔드포인트가 바뀌었습니당. 컴포지트 서버가 배포되는대로 해당 엔드포인트 이용해 주시면됩니다.
그리고 이전에 단일조회-> chat : {} , 다중조회 -> chats :{[]} 가 각각 그냥 데이터를 가지도록 바뀌었습니다. 이미지 첨부하겠습니다.

