### PR TITLE
[FIX] 익명으로 게시글 디테일 접근 가능, 좋아요 확인 로직의 분리

### DIFF
--- a/community/src/main/java/com/jumunseo/community/domain/board/controller/BoardQueryController.java
+++ b/community/src/main/java/com/jumunseo/community/domain/board/controller/BoardQueryController.java
@@ -46,4 +46,10 @@ public class BoardQueryController {
     public ResponseEntity<Result<?>> getBoardDetail(@RequestHeader("email") String userId, @PathVariable Long id) {
         return ResponseEntity.ok().body(Result.successResult(boardService.getBoard(id, userId)));
     }
+
+    // 게시글 좋아요 여부
+    @GetMapping("/like/{id}")
+    public ResponseEntity<Result<?>> getBoardLike(@RequestHeader("email") String userId, @PathVariable Long id) {
+        return ResponseEntity.ok().body(Result.successResult(boardService.isLiked(id, userId)));
+    }
 }

--- a/community/src/main/java/com/jumunseo/community/domain/board/service/BoardService.java
+++ b/community/src/main/java/com/jumunseo/community/domain/board/service/BoardService.java
@@ -31,6 +31,8 @@ public interface BoardService {
     List<BoardListPhotoResponseDto> getBoardPhotoListByLatest(Long index);
 
     // 6. 게시글 좋아요 (토글)
-
     void Like(Long boardId, String userId);
+
+    // 7. 게시글 좋아요 여부
+    boolean isLiked(Long boardId, String email);
 }

--- a/community/src/main/java/com/jumunseo/community/domain/board/service/BoardServiceImpl.java
+++ b/community/src/main/java/com/jumunseo/community/domain/board/service/BoardServiceImpl.java
@@ -108,7 +108,12 @@ public class BoardServiceImpl implements BoardService {
         ) -> new NoBoardException("해당 게시글이 존재하지 않습니다."));
         board.addViewCount();
         BoardResponseDto boardResponseDto = mapper.entityToBoardResponse(board);
-        boardResponseDto.setMy_Like(likeRepository.findByBoardAndUserId(board, userId).isPresent());
+        if(userId.equals("UNSIGNED")) {
+            boardResponseDto.setMy_Like(false);
+        }
+        else {
+            boardResponseDto.setMy_Like(likeRepository.findByBoardAndUserId(board, userId).isPresent());
+        }
         return boardResponseDto; // 게시글 조회
     }
 

--- a/community/src/main/java/com/jumunseo/community/domain/board/service/BoardServiceImpl.java
+++ b/community/src/main/java/com/jumunseo/community/domain/board/service/BoardServiceImpl.java
@@ -201,4 +201,12 @@ public class BoardServiceImpl implements BoardService {
             likeRepository.save(like);
         }
     }
+
+    @Override
+    public boolean isLiked(Long boardId, String email) {
+        Board board = boardRepository.findById(boardId).orElseThrow((
+        ) -> new NoBoardException("해당 게시글이 존재하지 않습니다."));
+
+        return likeRepository.findByBoardAndUserId(board, email).isPresent();
+    }
 }

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/CommunityCommandController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/command/controller/CommunityCommandController.java
@@ -40,7 +40,8 @@ public class CommunityCommandController {
     @PostMapping("/board/create")
     @Tag(name = "Community Command")
     @Operation(summary = "Posting Create", description = "게시글 생성 메소드")
-    public ResponseEntity<Result<?>> createBoard(HttpServletRequest request, @RequestPart BoardRequestDto boardRequestDto, @RequestPart(required = false) List<MultipartFile> files) {
+    public ResponseEntity<Result<?>> createBoard(HttpServletRequest request, @RequestPart BoardRequestDto boardRequestDto,
+                                                 @RequestPart(required = false) List<MultipartFile> files) {
         try {
             List<String> imageUrls = new ArrayList<>();
             for (MultipartFile file : files) {

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
@@ -172,6 +172,28 @@ public class CommunityQueryController {
         }
     }
 
+    // 좋아요 여부 조회
+    // 토큰 필요
+    @GetMapping("/like/{board_id}")
+    @Tag(name = "Community Query")
+    @Operation(summary = "Like Check", description = "좋아요 여부 조회")
+    private ResponseEntity<Result<?>> getLike(HttpServletRequest req, @PathVariable Long board_id) {
+        Mono<JSONObject> mono = webClient.get()
+                .uri(COMMUNITY_URL +"/community/board/like/" + board_id)
+                .header("email", req.getAttribute("email").toString())
+                .retrieve()
+                // 4-- 에러 -> 요청 오류
+                .onStatus(HttpStatusCode::is4xxClientError, res -> Mono.error(
+                        new WebClient4xxException(res.bodyToMono(String.class).toString())
+                ))
+                // 5-- 에러 -> 시스템 오류
+                .onStatus(HttpStatusCode::is5xxServerError, res -> Mono.error(
+                        new WebClient5xxException(res.bodyToMono(String.class).toString())
+                ))
+                .bodyToMono(JSONObject.class);
+        return ResponseEntity.ok(Result.successResult(mono.block().get("data")));
+    }
+
 
     // 댓글 리스트 조회
     // 토큰 필요 X

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
@@ -126,9 +126,13 @@ public class CommunityQueryController {
     @Tag(name = "Community Query")
     @Operation(summary = "Community Detail", description = "커뮤니티 상세 조회")
     private ResponseEntity<Result<?>> getCommunityDetail(@PathVariable Long id, HttpServletRequest req) throws JsonProcessingException {
+        String email = req.getAttribute("email").toString();
+        if (email == null) {
+            email = "UNSIGNED";
+        }
         Mono<JSONObject> mono = webClient.get()
                 .uri(COMMUNITY_URL +"/community/board/detail/" + id)
-                .header("email", req.getAttribute("email").toString())
+                .header("email", email)
                 .retrieve()
                 // 4-- 에러 -> 요청 오류
                 .onStatus(HttpStatusCode::is4xxClientError, res -> Mono.error(

--- a/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
+++ b/composite-service/src/main/java/com/jumunseo/compositeservice/query/controller/CommunityQueryController.java
@@ -126,10 +126,11 @@ public class CommunityQueryController {
     @Tag(name = "Community Query")
     @Operation(summary = "Community Detail", description = "커뮤니티 상세 조회")
     private ResponseEntity<Result<?>> getCommunityDetail(@PathVariable Long id, HttpServletRequest req) throws JsonProcessingException {
-        String email = req.getAttribute("email").toString();
+        String email = (String) req.getAttribute("email");
         if (email == null) {
             email = "UNSIGNED";
         }
+
         Mono<JSONObject> mono = webClient.get()
                 .uri(COMMUNITY_URL +"/community/board/detail/" + id)
                 .header("email", email)

--- a/debate/src/main/java/com/jumunseo/debate/domain/subject/repository/SubjectJPARepository.java
+++ b/debate/src/main/java/com/jumunseo/debate/domain/subject/repository/SubjectJPARepository.java
@@ -18,5 +18,8 @@ public interface SubjectJPARepository extends JpaRepository<Subject, Long> {
     @Query("SELECT new com.jumunseo.debate.domain.subject.dto.SubjectCollectDto(s.contents) FROM Subject s ORDER BY s.startTime DESC LIMIT 30")
     List<SubjectCollectDto> findTop30ByStartTimeOrderByStartTimeDesc(LocalDateTime startTime);
     Optional<Subject> findSubjectDtoById (Long id);
-    Optional<Subject> findTop1ByEndTimeBefore(LocalDateTime endTime);
+    Optional<Subject> findTop1ByEndTimeBeforeOrderByStartTimeDesc(LocalDateTime endTime);
+
+    // Test
+    Optional<Subject> findTop1ByOrderByIdDesc();
 }

--- a/debate/src/main/java/com/jumunseo/debate/domain/subject/service/SubjectService.java
+++ b/debate/src/main/java/com/jumunseo/debate/domain/subject/service/SubjectService.java
@@ -31,5 +31,5 @@ public interface SubjectService {
 
     SubjectSummary getSubjectSummary(Long subjectId);
 
-    Long getLatestSubjectSummary();
+    SubjectSummary getLatestSubjectSummary();
 }

--- a/debate/src/main/java/com/jumunseo/debate/domain/subject/service/SubjectServiceImpl.java
+++ b/debate/src/main/java/com/jumunseo/debate/domain/subject/service/SubjectServiceImpl.java
@@ -47,7 +47,7 @@ public class SubjectServiceImpl implements SubjectService{
             try {
                 // 시간이 지난 주제에 대해 요약을 하고, 해당 주제를 레디스 토픽에서 삭제한다.
                 // 1. 시간이 막 지난 주제를 가져온다.
-                Subject subject = subjectRepository.findTop1ByEndTimeBefore(LocalDateTime.now())
+                Subject subject = subjectRepository.findTop1ByEndTimeBeforeOrderByStartTimeDesc(LocalDateTime.now())
                         .orElseThrow(() -> new NotExistSubjectException("요약할 주제가 없습니다."));
 
                 // 2. 해당 주제를 레디스 토픽에서 삭제한다.
@@ -200,10 +200,9 @@ public class SubjectServiceImpl implements SubjectService{
 
     @Override
     @Transactional
-    public Long getLatestSubjectSummary(){
-        SubjectSummary subjectSummary = subjectSummartJPARepository.findTop1ByOrderByIdDesc().orElseThrow((
+    public SubjectSummary getLatestSubjectSummary(){
+        return subjectSummartJPARepository.findTop1ByOrderByIdDesc().orElseThrow((
         ) -> new NotExistSubjectException("최신 주제의 요약이 존재하지 않습니다."));
-        return subjectSummary.getId();
     }
 
     @Transactional

--- a/debate/src/main/java/com/jumunseo/debate/global/TestController.java
+++ b/debate/src/main/java/com/jumunseo/debate/global/TestController.java
@@ -53,12 +53,9 @@ public class TestController {
     // 3. 주제가 만료되고 나서 주제를 종료, 요약된 정보들을 반환.
     @GetMapping("/test")
     public ResponseEntity<Result<?>> test() {
-        System.out.println("0");
 
-        // 1. 주제 생성 일반적으로 주제 번호는 1이다.
         subjectService.addTestSubject();
-        Subject sub = subjectRepository.findById(1L).get();
-        System.out.println("1");
+        Subject sub = subjectRepository.findTop1ByOrderByIdDesc().get();
 
         // 2. opinion 생성 좌, 우 3개씩.
         Opinion opinionDtoL1 = Opinion.builder().content("맞다고 생각한다").type(MessageType.TALK).side(MessageSide.LEFT).subject(sub).userEmail("lms990427").time(LocalDateTime.now()).build();
@@ -79,8 +76,6 @@ public class TestController {
         opinionRepository.save(opinionDtoR3);
         opinionRepository.save(opinionDtoR4);
 
-        System.out.println("2");
-
         System.out.println("살이있는 주제" + subjectService.getLiveSubject());
         // 3. 주제 만료까지 대기. 요약 메소드를 호출.
         try {
@@ -92,10 +87,8 @@ public class TestController {
 
         subjectService.summarySubject();
 
-        System.out.println("3");
         // 4. 요약된 정보 반환.
-        SubjectSummary subjectSummary = subjectSummaryRepository.findById(1L).get();
-        System.out.println("4");
+        SubjectSummary subjectSummary = subjectSummaryRepository.findTop1ByOrderByIdDesc().get();
 
         return ResponseEntity.ok(Result.successResult(subjectSummary));
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 
resolved # 143


## 📝 작업 내용
> 사용자가 토큰 없이 게시글 디테일에 접근 가능하도록 변경,
어떤 게시물에 대한 사용자의 현재 좋아요 여부를 가져올 수 있는 API 추가


### ***📸 스크린샷 (선택)***


## ***💬 리뷰 요구사항(선택)***
